### PR TITLE
Introduce domain layer with DI and repository

### DIFF
--- a/TGbot_template-main/tg_bot_template/__init__.py
+++ b/TGbot_template-main/tg_bot_template/__init__.py
@@ -4,9 +4,19 @@ from aiogram.contrib.fsm_storage.redis import RedisStorage2
 
 from tg_bot_template.bot_lib.aiogram_overloads import DbDispatcher
 from tg_bot_template.config import settings
+from tg_bot_template.container import Container
+from tg_bot_template.db_infra import setup_db
 
 if settings.environment.local_test:
     storage = MemoryStorage()
 else:
     storage = RedisStorage2(settings.fsm_redis_host, db=settings.fsm_redis_db, password=settings.fsm_redis_pass)
+
+container = Container()
+session_factory = setup_db(settings)
+container.session_factory.override(session_factory)
+container.init_resources()
+container.wire(packages=["tg_bot_template"])
+
 dp = DbDispatcher(Bot(token=settings.tg_bot_token), storage=storage)  # type: ignore[no-untyped-call]
+dp.set_db_conn(session_factory)

--- a/TGbot_template-main/tg_bot_template/bot.py
+++ b/TGbot_template-main/tg_bot_template/bot.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, Type
+from typing import Any
 
 import aioschedule
 from aiogram import types
@@ -7,7 +7,7 @@ from aiogram.dispatcher import FSMContext
 from aiogram.dispatcher.filters import Text
 from aiogram.dispatcher.filters.state import StatesGroup
 from aiogram.utils import executor
-from aiogram.utils.exceptions import RetryAfter, BotBlocked
+from aiogram.utils.exceptions import BotBlocked
 from loguru import logger
 
 from . import dp
@@ -20,7 +20,7 @@ from .bot_lib.aiogram_overloads import DbDispatcher
 from .bot_lib.bot_feature import Feature, InlineButton, TgUser
 from .bot_lib.utils import bot_edit_callback_message, bot_safe_send_message, bot_safe_send_photo
 from .config import settings
-from .db_infra import db, setup_db
+from .db_infra import db
 
 # filters binding
 dp.filters_factory.bind(CreatorFilter)
@@ -90,7 +90,7 @@ async def add_form_info(msg: types.Message, state: FSMContext) -> None:
     await fill_form(msg=msg, feature=features.set_user_about, form=UserForm, state=state)
 
 
-async def fill_form(*, msg: types.Message, feature: Feature, form: Type[StatesGroup], state: FSMContext) -> None:
+async def fill_form(*, msg: types.Message, feature: Feature, form: type[StatesGroup], state: FSMContext) -> None:
     async with state.proxy() as data:
         data[feature.data_key] = msg.caption or msg.text
     await form.next()
@@ -246,5 +246,4 @@ async def on_shutdown(dispatcher: DbDispatcher) -> None:
 
 
 if __name__ == "__main__":
-    dp.set_db_conn(conn=setup_db(settings))
     executor.start_polling(dp, on_startup=on_startup, on_shutdown=on_shutdown)

--- a/TGbot_template-main/tg_bot_template/bot_lib/aiogram_overloads.py
+++ b/TGbot_template-main/tg_bot_template/bot_lib/aiogram_overloads.py
@@ -1,17 +1,17 @@
 from aiogram import Dispatcher, types
 from aiogram.dispatcher.filters import BoundFilter
-from peewee_async import Manager
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 
 class DbDispatcher(Dispatcher):  # type: ignore[misc]
     def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
         super().__init__(*args, **kwargs)
-        self._db_conn: Manager | None = None
+        self._db_conn: async_sessionmaker[AsyncSession] | None = None
 
-    def set_db_conn(self, conn: Manager) -> None:
+    def set_db_conn(self, conn: async_sessionmaker[AsyncSession]) -> None:
         self._db_conn = conn
 
-    def get_db_conn(self) -> Manager:
+    def get_db_conn(self) -> async_sessionmaker[AsyncSession]:
         return self._db_conn
 
 

--- a/TGbot_template-main/tg_bot_template/container.py
+++ b/TGbot_template-main/tg_bot_template/container.py
@@ -1,0 +1,12 @@
+from dependency_injector import containers, providers
+
+from tg_bot_template.config import settings
+from tg_bot_template.db_infra import setup_db
+from tg_bot_template.db_infra.unit_of_work import SqlAlchemyUnitOfWork
+
+
+class Container(containers.DeclarativeContainer):
+    wiring_config = containers.WiringConfiguration(packages=["tg_bot_template"])
+
+    session_factory = providers.Singleton(setup_db, settings)
+    unit_of_work = providers.Factory(SqlAlchemyUnitOfWork, session_factory=session_factory)

--- a/TGbot_template-main/tg_bot_template/db_infra/db.py
+++ b/TGbot_template-main/tg_bot_template/db_infra/db.py
@@ -1,62 +1,82 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from aiocache import cached
 from aiocache.serializers import PickleSerializer
+from dependency_injector.wiring import Provide, inject
 from loguru import logger
-from peewee_async import Manager
 
-from tg_bot_template import dp
 from tg_bot_template.bot_infra.states import UserFormData
 from tg_bot_template.bot_lib.bot_feature import TgUser
-from tg_bot_template.db_infra.models import Users
+from tg_bot_template.container import Container
+from tg_bot_template.domain.models import User
+from tg_bot_template.domain.uow import AbstractUnitOfWork
 
 
-def _get_conn() -> Manager:
-    return dp.get_db_conn()
-
-
-async def check_user_registered(*, tg_user: TgUser) -> bool:
-    return bool(await get_user_for_filters(tg_user=tg_user))
+@inject
+async def check_user_registered(*, tg_user: TgUser, uow: AbstractUnitOfWork = Provide[Container.unit_of_work]) -> bool:
+    async with uow:
+        return await uow.users.get_by_social_id(tg_user.tg_id) is not None
 
 
 @cached(ttl=0.2, serializer=PickleSerializer())
-async def get_user_for_filters(*, tg_user: TgUser) -> Users | None:
-    return await get_user(tg_user=tg_user)
+@inject
+async def get_user_for_filters(
+    *, tg_user: TgUser, uow: AbstractUnitOfWork = Provide[Container.unit_of_work]
+) -> User | None:
+    return await get_user(tg_user=tg_user, uow=uow)
 
 
-async def get_user(*, tg_user: TgUser) -> Users | None:
-    try:
-        user = await _get_conn().get(Users, social_id=tg_user.tg_id)
-    except Exception:
-        return None
-    else:
-        user.username = tg_user.username
-        await _get_conn().update(user)
-        return user  # type: ignore[no-any-return]
+@inject
+async def get_user(*, tg_user: TgUser, uow: AbstractUnitOfWork = Provide[Container.unit_of_work]) -> User | None:
+    async with uow:
+        user = await uow.users.get_by_social_id(tg_user.tg_id)
+        if user is not None:
+            user.username = tg_user.username
+            await uow.users.update(user)
+        return user
 
 
-async def create_user(*, tg_user: TgUser) -> None:
-    await _get_conn().create(
-        Users, social_id=tg_user.tg_id, username=tg_user.username, registration_date=datetime.now()  # noqa: DTZ005
+@inject
+async def create_user(*, tg_user: TgUser, uow: AbstractUnitOfWork = Provide[Container.unit_of_work]) -> None:
+    user = User(
+        id=None,
+        social_id=tg_user.tg_id,
+        username=tg_user.username,
+        registration_date=datetime.now(timezone.utc),
     )
+    async with uow:
+        await uow.users.add(user)
     logger.info(f"New user[{tg_user.username}] registered")
 
 
-async def update_user_info(*, tg_user: TgUser, user_form_data: UserFormData) -> None:
-    user = await get_user(tg_user=tg_user)
-    if user is not None:
-        user.name = user_form_data.name
-        user.info = user_form_data.info
-        user.photo = user_form_data.photo
-        await _get_conn().update(user)
+@inject
+async def update_user_info(
+    *,
+    tg_user: TgUser,
+    user_form_data: UserFormData,
+    uow: AbstractUnitOfWork = Provide[Container.unit_of_work],
+) -> None:
+    async with uow:
+        user = await uow.users.get_by_social_id(tg_user.tg_id)
+        if user is not None:
+            user.name = user_form_data.name
+            user.info = user_form_data.info
+            user.photo = user_form_data.photo
+            await uow.users.update(user)
 
 
-async def incr_user_taps(*, tg_user: TgUser) -> None:
-    user = await get_user(tg_user=tg_user)
-    if user is not None:
-        user.taps += 1
-        await _get_conn().update(user)
+@inject
+async def incr_user_taps(*, tg_user: TgUser, uow: AbstractUnitOfWork = Provide[Container.unit_of_work]) -> None:
+    async with uow:
+        user = await uow.users.get_by_social_id(tg_user.tg_id)
+        if user is not None:
+            user.taps += 1
+            await uow.users.update(user)
 
 
-async def get_all_users() -> list[Users]:
-    return list(await _get_conn().execute(Users.select().order_by(Users.taps.desc())))
+@inject
+async def get_all_users(
+    uow: AbstractUnitOfWork = Provide[Container.unit_of_work],
+) -> list[User]:
+    async with uow:
+        return await uow.users.list_ordered_by_taps()

--- a/TGbot_template-main/tg_bot_template/db_infra/models.py
+++ b/TGbot_template-main/tg_bot_template/db_infra/models.py
@@ -1,12 +1,16 @@
-import peewee
+from sqlalchemy import BigInteger, Column, DateTime, Integer, MetaData, String, Table, Text
 
+metadata = MetaData()
 
-class Users(peewee.Model):  # type: ignore[misc]
-    id = peewee.PrimaryKeyField(null=False)
-    social_id = peewee.BigIntegerField(null=False)
-    username = peewee.CharField(max_length=50)
-    registration_date = peewee.DateTimeField(null=True)
-    taps = peewee.BigIntegerField(default=0)
-    name = peewee.TextField(null=True)
-    info = peewee.TextField(null=True)
-    photo = peewee.TextField(null=True)
+users = Table(
+    "users",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("social_id", BigInteger, nullable=False, unique=True),
+    Column("username", String(50)),
+    Column("registration_date", DateTime),
+    Column("taps", BigInteger, default=0),
+    Column("name", Text),
+    Column("info", Text),
+    Column("photo", Text),
+)

--- a/TGbot_template-main/tg_bot_template/db_infra/repositories.py
+++ b/TGbot_template-main/tg_bot_template/db_infra/repositories.py
@@ -1,0 +1,46 @@
+from sqlalchemy import insert, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tg_bot_template.db_infra.models import users
+from tg_bot_template.domain.models import User
+from tg_bot_template.domain.repositories import AbstractUserRepository
+
+
+class SqlAlchemyUserRepository(AbstractUserRepository):
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get_by_social_id(self, social_id: int) -> User | None:
+        res = await self._session.execute(select(users).where(users.c.social_id == social_id))
+        row = res.mappings().first()
+        return User(**row) if row else None
+
+    async def add(self, user: User) -> None:
+        await self._session.execute(
+            insert(users).values(
+                social_id=user.social_id,
+                username=user.username,
+                registration_date=user.registration_date,
+                taps=user.taps,
+                name=user.name,
+                info=user.info,
+                photo=user.photo,
+            )
+        )
+
+    async def update(self, user: User) -> None:
+        await self._session.execute(
+            update(users)
+            .where(users.c.social_id == user.social_id)
+            .values(
+                username=user.username,
+                taps=user.taps,
+                name=user.name,
+                info=user.info,
+                photo=user.photo,
+            )
+        )
+
+    async def list_ordered_by_taps(self) -> list[User]:
+        res = await self._session.execute(select(users).order_by(users.c.taps.desc()))
+        return [User(**row) for row in res.mappings().all()]

--- a/TGbot_template-main/tg_bot_template/db_infra/unit_of_work.py
+++ b/TGbot_template-main/tg_bot_template/db_infra/unit_of_work.py
@@ -1,0 +1,28 @@
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from tg_bot_template.db_infra.repositories import SqlAlchemyUserRepository
+from tg_bot_template.domain.repositories import AbstractUserRepository
+from tg_bot_template.domain.uow import AbstractUnitOfWork
+
+
+class SqlAlchemyUnitOfWork(AbstractUnitOfWork):
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._session_factory = session_factory
+
+    async def __aenter__(self) -> "SqlAlchemyUnitOfWork":
+        self.session = self._session_factory()
+        self.users: AbstractUserRepository = SqlAlchemyUserRepository(self.session)
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        if exc is None:
+            await self.commit()
+        else:
+            await self.rollback()
+        await self.session.close()
+
+    async def commit(self) -> None:
+        await self.session.commit()
+
+    async def rollback(self) -> None:
+        await self.session.rollback()

--- a/TGbot_template-main/tg_bot_template/domain/models.py
+++ b/TGbot_template-main/tg_bot_template/domain/models.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass
+class User:
+    id: int | None
+    social_id: int
+    username: str | None
+    registration_date: datetime | None
+    taps: int = 0
+    name: str | None = None
+    info: str | None = None
+    photo: str | None = None

--- a/TGbot_template-main/tg_bot_template/domain/repositories.py
+++ b/TGbot_template-main/tg_bot_template/domain/repositories.py
@@ -1,0 +1,17 @@
+from abc import ABC, abstractmethod
+
+from .models import User
+
+
+class AbstractUserRepository(ABC):
+    @abstractmethod
+    async def get_by_social_id(self, social_id: int) -> User | None: ...
+
+    @abstractmethod
+    async def add(self, user: User) -> None: ...
+
+    @abstractmethod
+    async def update(self, user: User) -> None: ...
+
+    @abstractmethod
+    async def list_ordered_by_taps(self) -> list[User]: ...

--- a/TGbot_template-main/tg_bot_template/domain/uow.py
+++ b/TGbot_template-main/tg_bot_template/domain/uow.py
@@ -1,0 +1,19 @@
+from abc import ABC, abstractmethod
+
+from .repositories import AbstractUserRepository
+
+
+class AbstractUnitOfWork(ABC):
+    users: AbstractUserRepository
+
+    async def __aenter__(self):
+        return self
+
+    @abstractmethod
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None: ...
+
+    @abstractmethod
+    async def commit(self) -> None: ...
+
+    @abstractmethod
+    async def rollback(self) -> None: ...


### PR DESCRIPTION
## Summary
- implement domain models and repository interfaces
- add SQLAlchemy repository and unit of work
- provide DI container
- refactor dispatcher to use async session factory
- adapt bot initialization and DB helpers

## Testing
- `ruff check --fix tg_bot_template`
- `make lint` *(fails: Error importing plugin `pydantic.mypy`)*

------
https://chatgpt.com/codex/tasks/task_e_685f0373b564832e80ae858f7d154797